### PR TITLE
c++ standard settings 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ set(${PROJECT_NAME}_VERSION_PATCH 02)
 set(${PROJECT_NAME}_VERSION "${PandoraSDK_VERSION_MAJOR}.${PandoraSDK_VERSION_MINOR}.${PandoraSDK_VERSION_PATCH}")
 
 #-------------------------------------------------------------------------------------------------------------------------------------------
+# Default C++ standard
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+#-------------------------------------------------------------------------------------------------------------------------------------------
 # Dependencies
 find_path(pandora_cmake_path "PandoraCMakeSettings.cmake" "${CMAKE_CURRENT_LIST_DIR}/cmakemodules")
 if (pandora_cmake_path)
@@ -66,6 +72,10 @@ endif()
 
 if(CMAKE_CXX_COMPILER)
     list(APPEND COMMON_CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+endif()
+
+if(CMAKE_CXX_STANDARD)
+    list(APPEND COMMON_CMAKE_ARGS "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
 endif()
 
 if(NOT LAR_CONTENT_LIBRARY_NAME STREQUAL "LArPandoraContent")


### PR DESCRIPTION
Hi Cambridge!

I've been struggling with ROOT and PandoraPFA compatibility.
I am using gcc 8 and c++14 to compile our iLCSoft stack. If ROOT is compiled with c++14 it breaks the compilation of PandoraMonitoring:

```shell
[ 43%] Performing build step for 'PandoraMonitoring'
Scanning dependencies of target PandoraMonitoring
[ 25%] Building CXX object CMakeFiles/PandoraMonitoring.dir/src/PandoraMonitoring.cc.o
[ 50%] Building CXX object CMakeFiles/PandoraMonitoring.dir/src/PandoraMonitoringApi.cc.o
[ 75%] Building CXX object CMakeFiles/PandoraMonitoring.dir/src/TTreeWrapper.cc.o
In file included from /home/ilc/ilcsoft/HEAD-2019-10-09/root/6.18.04/include/TString.h:28,
                 from /home/ilc/ilcsoft/HEAD-2019-10-09/root/6.18.04/include/TNamed.h:26,
                 from /home/ilc/ilcsoft/HEAD-2019-10-09/root/6.18.04/include/TSystem.h:34,
                 from /home/ilc/ilcsoft/HEAD-2019-10-09/PandoraPFANew/HEAD/PandoraMonitoring-origin/master/src/TTreeWrapper.cc:10:
/home/ilc/ilcsoft/HEAD-2019-10-09/root/6.18.04/include/ROOT/RStringView.hxx:32:37: error: 'experimental' in namespace 'std' does not name a 
type
    using basic_string_view = ::std::experimental::basic_string_view<_CharT,_Traits>;
                                     ^~~~~~~~~~~~
/home/ilc/ilcsoft/HEAD-2019-10-09/root/6.18.04/include/ROOT/RStringView.hxx:35:12: error: 'basic_string_view' does not name a type; did you 
mean 'basic_stringstream'?
    typedef basic_string_view<char> string_view;
            ^~~~~~~~~~~~~~~~~
            basic_stringstream
# ..... long stack .....
```
The reason was because C++11 is forced in PandoraMonitoring and I can't change it by command line:

https://github.com/PandoraPFA/PandoraMonitoring/blob/92ad7e8b4a078c2483740e0c0dfb9bbfe6dbab2d/CMakeLists.txt#L38

This is also true for other packages. As a first step I forward the CXX standard to external projects **without changing the CXX_FLAGS** in the respective CMakeLists.txt. It seems to work but I don't find it clean. I get for example this compilation line:

```shell
[  1%] Building CXX object CMakeFiles/PandoraSDK.dir/src/Api/PandoraApi.cc.o
/usr/bin/c++  -DPandoraSDK_EXPORTS -I/home/eteremi/soft/PandoraUpdate/PandoraPFA/PandoraSDK-origin/master/include  -Wall -Wextra -Werror -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing -std=c++11  -O2 -g -DNDEBUG -fPIC   -std=gnu++14 -o CMakeFiles/PandoraSDK.dir/src/Api/PandoraApi.cc.o -c /home/eteremi/soft/PandoraUpdate/PandoraPFA/PandoraSDK-origin/master/src/Api/PandoraApi.cc
```

where you can see the forced `-std=c++11` and `-std=gnu++14` set by CMake.

This pull request can be merge without any problem but you might want to update all other packages to get it properly. To do this you just need to remove the flag `c++11` from all CXX_FLAGS in all packages and let CMake set it using the broadcasted  CMAKE_CXX_STANDARD from the PandoraPFA meta package.

Changes in this pull request:
- Set default CXX standard to 11. 
- Broadcast CMAKE_CXX_STANDARD to external projects