### PR TITLE
Install config files to lib/cmake/${PROJECT_NAME}

### DIFF
--- a/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake
+++ b/cmakemodules/MacroPandoraGeneratePackageConfigFiles.cmake
@@ -11,7 +11,7 @@ MACRO( PANDORA_GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake/${PROJECT_NAME} )
             ENDIF()
         ENDIF()
 
@@ -22,7 +22,7 @@ MACRO( PANDORA_GENERATE_PACKAGE_CONFIGURATION_FILES )
                 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/cmake/${arg}.in"
                                 "${PROJECT_BINARY_DIR}/${arg}" @ONLY
                 )
-                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION . )
+                INSTALL( FILES "${PROJECT_BINARY_DIR}/${arg}" DESTINATION lib/cmake/${PROJECT_NAME} )
             ENDIF( EXISTS "${PROJECT_SOURCE_DIR}/cmake/${arg}.in" )
         ENDIF()
 


### PR DESCRIPTION
`lib/cmake/${PROJECT_NAME}` is the standard location for Config files and if a package is found in `CMAKE_PREFIX_PATH`, `lib/cmake/${PROJECT_NAME}` will be used to look for the config files. Currently, these are being installed to the installation prefix.

The purpose of this PR is to make sure the Pandora packages work with the LCG views, that will install everything from `lib` in a common folder for all packages. Since the current Config files are at the top level, they are not installed. I did the same changes for https://github.com/iLCSoft/iLCUtil/pull/36 and now we have a view-based stack and a non view-based stack working.

The changes in this PR should only be a problem if there is a package with a name that is being called with `find_package` with a different name. We had that happen for the RAIDA package that is also being found with `find_package(AIDA)`. Why? Because now things are installed into `lib/cmake/RAIDA` (and `find_package(AIDA)` will look into `lib/cmake/AIDA`). See https://github.com/iLCSoft/RAIDA/pull/8 and https://github.com/iLCSoft/RAIDA/pull/9.